### PR TITLE
Update st7789.h

### DIFF
--- a/roo_display/driver/st7789.h
+++ b/roo_display/driver/st7789.h
@@ -55,4 +55,10 @@ template <int pinCS, int pinDC, int pinRST, typename Spi = DefaultSpi,
 using St7789spi_240x240 = St7789spi_Generic<pinCS, pinDC, pinRST, 240, 240, 0,
                                             0, 0, 80, Spi, SpiSettings, Gpio>;
 
+template <int pinCS, int pinDC, int pinRST, typename Spi = DefaultSpi,
+          typename SpiSettings = st7789::DefaultSpiSettings,
+          typename Gpio = DefaultGpio>
+using St7789spi_172x320 = St7789spi_Generic<pinCS, pinDC, pinRST, 172, 320, 34,
+                                            0, 34, 0, Spi, SpiSettings, Gpio>;
+  
 }  // namespace roo_display


### PR DESCRIPTION
Added template for new curved corner display size (1.47" 172x320 IPS) now available from China.
Tested with generic displays similar to (Adafruit Product ID: 5393)

I have successfully run all Examples in the library. 

NOTE: The displays I tested default to portrait orientation (as indicated by 172x320) and lose some pixels to the curved corners.