### PR TITLE
Three new displays for ST7789 (st7789.h)

### DIFF
--- a/roo_display/driver/st7789.h
+++ b/roo_display/driver/st7789.h
@@ -56,5 +56,11 @@ template <int pinCS, int pinDC, int pinRST, typename Spi = DefaultSpi,
           typename Gpio = DefaultGpio>
 using St7789spi_172x320 = St7789spi_Generic<pinCS, pinDC, pinRST, 172, 320, 34,
                                             0, 34, 0, Spi, SpiSettings, DefaultGpio>;
+
+template <int pinCS, int pinDC, int pinRST, typename Spi = DefaultSpi,
+          typename SpiSettings = st7789::DefaultSpiSettings,
+          typename Gpio = DefaultGpio>
+using St7789spi_135x240 = St7789spi_Generic<pinCS, pinDC, pinRST, 135, 240, 
+                          0, 40, 53, 0, Spi, SpiSettings, DefaultGpio>;
   
 }  // namespace roo_display

--- a/roo_display/driver/st7789.h
+++ b/roo_display/driver/st7789.h
@@ -54,6 +54,12 @@ using St7789spi_240x240 = St7789spi_Generic<pinCS, pinDC, pinRST, 240, 240, 0,
 template <int pinCS, int pinDC, int pinRST, typename Spi = DefaultSpi,
           typename SpiSettings = st7789::DefaultSpiSettings,
           typename Gpio = DefaultGpio>
+using St7789spi_240x280 = St7789spi_Generic<pinCS, pinDC, pinRST, 240, 280, 0,
+                                            20, 0, 0, Spi, SpiSettings, Gpio>;
+  
+template <int pinCS, int pinDC, int pinRST, typename Spi = DefaultSpi,
+          typename SpiSettings = st7789::DefaultSpiSettings,
+          typename Gpio = DefaultGpio>
 using St7789spi_172x320 = St7789spi_Generic<pinCS, pinDC, pinRST, 172, 320, 34,
                                             0, 34, 0, Spi, SpiSettings, DefaultGpio>;
 


### PR DESCRIPTION
Here finally are the new display settings I added for 3 display sizes:

1.14" 135x240
1.69" 240x280
1.9"  170x320 (as in TTGO T-Display S3)

Let me know if anything is amiss.