### PR TITLE
stack mem alloc fix

### DIFF
--- a/src/roo_display/image/png/lib/PNGdec.h
+++ b/src/roo_display/image/png/lib/PNGdec.h
@@ -130,7 +130,7 @@ typedef void (PNG_DRAW_CALLBACK)(PNGDRAW *);
 typedef void (PNG_CLOSE_CALLBACK)(void *pHandle);
 
 //
-// our private structure to hold a JPEG image decode state
+// our private structure to hold a PNG image decode state
 //
 typedef struct png_image_tag
 {

--- a/src/roo_display/image/png/png.cpp
+++ b/src/roo_display/image/png/png.cpp
@@ -118,6 +118,8 @@ bool PngDecoder::open(const roo_io::MultipassResource &resource, int16_t &width,
                       int16_t &height) {
   input_ = resource.open();
   if (input_ == nullptr) return false;
+  // Zero the heap-allocated PNGIMAGE directly to avoid a stack allocation. The extra temporary object may
+  // spike the main task stack and trigger stack-protection faults
   memset(pngdec_.get(), 0, sizeof(PNGIMAGE));
   pngdec_->pfnRead = png_read;
   pngdec_->pfnSeek = png_seek;

--- a/src/roo_display/image/png/png.cpp
+++ b/src/roo_display/image/png/png.cpp
@@ -118,7 +118,7 @@ bool PngDecoder::open(const roo_io::MultipassResource &resource, int16_t &width,
                       int16_t &height) {
   input_ = resource.open();
   if (input_ == nullptr) return false;
-  *pngdec_ = {};
+  memset(pngdec_.get(), 0, sizeof(PNGIMAGE));
   pngdec_->pfnRead = png_read;
   pngdec_->pfnSeek = png_seek;
   pngdec_->pfnDraw = png_draw;


### PR DESCRIPTION
C++ initializer `*pngdec_ = {}` forces the compiler to create a second copy on the stack just to zero it out before copying it to the heap.

`memset` ensures the heap is used as intended without the unnecessary stack spike preventing `Stack protection fault`