### PR TITLE
Reactivate PENIRQ after TS read

### DIFF
--- a/src/roo_display/driver/touch_xpt2046.h
+++ b/src/roo_display/driver/touch_xpt2046.h
@@ -157,6 +157,7 @@ int TouchXpt2046<pinCS, Spi, Gpio>::readTouch(TouchPoint* touch_point) {
   }
 
   bool touched = false;
+  bool settled_enough = false;
   for (int i = 0; i < kMaxConversionAttempts; ++i) {
     ConversionResult result =
         single_conversion(device_, z_threshold, &x_tmp, &y_tmp, &z_tmp);
@@ -170,24 +171,28 @@ int TouchXpt2046<pinCS, Spi, Gpio>::readTouch(TouchPoint* touch_point) {
       count++;
     }
     if (settled_conversions >= kMinSettledConversions) {
-      // We got enough settled conversions to return a result.
-      if (touched) {
-        touch_point->id = 0;
-        touch_point->x = 4095 - (x_sum / count);
-        touch_point->y = 4095 - (y_sum / count);
-        touch_point->z = z_max;
-        // if (z >= kInitialTouchZThreshold) {
-        //   // We got a definite press.
-        //   latest_confirmed_pressed_timestamp_ = now;
-        // }
-      }
-      pressed_ = touched;
-      return pressed_ ? 1 : 0;
+      settled_enough = true;
+      break;
     }
   }
-  // No reliable readout despite numerous attempts - aborting.
-  pressed_ = false;
-  return 0;
-};
+
+  // Re-enable PENIRQ: send any control byte with PD0=0 while CS is still low.
+  device_.transfer(roo::byte{0x82});
+  device_.transfer16(0x0000);  // clock out response, discard
+
+  if (!settled_enough) {
+    pressed_ = false;
+    return 0;
+  }
+
+  if (touched) {
+    touch_point->id = 0;
+    touch_point->x = 4095 - (x_sum / count);
+    touch_point->y = 4095 - (y_sum / count);
+    touch_point->z = z_max;
+  }
+  pressed_ = touched;
+  return pressed_ ? 1 : 0;
+}
 
 }  // namespace roo_display


### PR DESCRIPTION
When using TS interrupt pin to get notified about touch down/up state, PENIRQ needs to be reenabled after read.

from datasheet:

> The PENIRQ output is disabled and high during the measurement cycle for battery monitor, auxiliary input, and
> chip temperature. If the last control byte written to the XPT2046 contains PD0 = 1, the pen-interrupt output
> function is disabled and is not able to detect when the screen is touched. In order to re-enable the pen-interrupt
> output function under these circumstances, a control byte needs to be written to the XPT2046 with PD0 = 0. If the
> last control byte written to the XPT2046 contains PD0 = 0, the pen-interrupt output function is enabled at the end
> of the conversion. 